### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/adsabs/aws_elk.png?label=ready&title=Ready)](https://waffle.io/adsabs/aws_elk)
 # AWS Elasticsearch/Logstash/Kibana stack for centralised logging of the ADSAWS
 
 # Setup


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/adsabs/aws_elk

This was requested by a real person (user jonnybazookatone) on waffle.io, we're not trying to spam you.
